### PR TITLE
Fix Sass compiling error

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,4 +1,4 @@
-*/*
+/*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.
  *
@@ -14,7 +14,7 @@
  *= require_self
  */
 
- $white_opaque: rgba(250, 250, 250, .3);
+$white_opaque: rgba(250, 250, 250, .3);
 $dark: #1F7972;
 
 * {


### PR DESCRIPTION
removed asterisk from first line which sass perceived as a selector.
Also un-indented `$white_opaque` selector.
